### PR TITLE
Investigate download resume issue

### DIFF
--- a/pages/about.jsx
+++ b/pages/about.jsx
@@ -2,21 +2,13 @@ import Link from 'next/link';
 import styles from '../styles/AboutPage.module.css';
 
 const AboutPage = () => {
-  const handleDownload = async () => {
-    const url = 'https://utfs.io/f/R5EIkIsFyzDgJN1W1W9lhZrgInFsjvak13dxcKPMEqQ0bRCo';
-    try {
-      const response = await fetch(url);
-      const blob = await response.blob();
-      const downloadUrl = window.URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = downloadUrl;
-      link.download = 'Omar_Hisham_Resume.pdf';
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-    } catch (error) {
-      console.error('Download failed:', error);
-    }
+  const handleDownload = () => {
+    const link = document.createElement('a');
+    link.href = '/Omar_Hisham_Resume.pdf'; // File should be in public directory
+    link.download = 'Omar_Hisham_Resume.pdf';
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
   };
 
   return (


### PR DESCRIPTION
Update resume download to use a local file path because the external URL was broken.

The resume download functionality was failing because the external URL `https://utfs.io/f/R5EIkIsFyzDgJN1W1W9lhZrgInFsjvak13dxcKPMEqQ0bRCo` was returning a 404 Not Found error, making the resume inaccessible. This PR changes the download mechanism to reference a local file, `/Omar_Hisham_Resume.pdf`, which needs to be placed in the `public` directory.